### PR TITLE
The algorithm for comparing ghc-mod's versions doesn't work well.

### DIFF
--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -331,6 +331,8 @@ function! ghcmod#check_version(version)"{{{
   for l:i in range(0, 2)
     if a:version[l:i] > s:ghc_mod_version[l:i]
       return 0
+    elseif a:version[l:i] < s:ghc_mod_version[l:i]
+      return 1
     endif
   endfor
   return 1


### PR DESCRIPTION
Supposing an installed ghc-mod's version is "1.2.3", ghcmod#check_version([1, 1, 4]) returns zero.
