### PR TITLE
Add a way to make ghc-mod's execution directory customizable

### DIFF
--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -403,7 +403,11 @@ function! s:system(...)"{{{
 endfunction"}}}
 
 function! s:plineopen2(...)"{{{
-  lcd `=expand('%:p:h')`
+  if empty(g:ghcmod_use_basedir)
+    lcd `=expand('%:p:h')`
+  else
+    lcd `=g:ghcmod_use_basedir`
+  endif
   let l:ret = call('vimproc#plineopen2', a:000)
   lcd -
   return l:ret

--- a/doc/ghcmod.txt
+++ b/doc/ghcmod.txt
@@ -102,6 +102,16 @@ g:ghcmod_type_highlight                              *g:ghcmod_type_highlight*
 	let ghcmodType ctermbg=yellow
 	let g:ghcmod_type_highlight = 'ghcmodType'
 <
+g:ghcmod_use_basedir                                    *g:ghcmod_use_basedir*
+	The directory to execute ghc-mod from. This can have an effect
+	particularly on template Haskell splices that expect to find certain
+	files in certain places. A good practice in these cases is to make
+	them work from the projects base directory, and open Vim from there.
+>
+	let g:ghcmod_use_basedir = getcwd()
+<
+	If you do not set it, ghcmod will be executed from the folder the file
+	current Haskell file is contained in.
 
 ==============================================================================
 CUSTOMIZE                                                   *ghcmod-customize*


### PR DESCRIPTION
This allows us to modify from where ghcmod is executed. Always executing
it from the folder the current file resides in can cause problems with,
for example, Yesod's scaffolding, where some of the splices expect files
to live in certain places relative to the compiler's working directory.

To explain, consider the following: use `yesod init` to create a new default Yesod project, and cd to the new project's directory. Then:

```
% ghc-mod check Settings/StaticFiles.hs
# no problems reported
% cd Settings
% ghc-mod check StaticFiles.hs
# returns: StaticFiles.hs:1:1:Exception when trying to run compile-time code:  static: getDirectoryContents: does not exist (No such file or directory)  Code: staticFiles staticDir
```

Making it possible to set ghc-mod's working directory explicitly allows the user to use Yesod's default scaffolding with ghcmod-vim. There might be another fix, but I can't think of any.
