### PR TITLE
Support for ghcmod's info command

### DIFF
--- a/after/ftplugin/haskell/ghcmod.vim
+++ b/after/ftplugin/haskell/ghcmod.vim
@@ -31,6 +31,7 @@ else
 endif
 
 command! -buffer -nargs=0 GhcModType echo ghcmod#type()[1]
+command! -buffer -nargs=0 GhcModInfo echo ghcmod#info()
 command! -buffer -nargs=0 GhcModTypeClear call ghcmod#type_clear()
 command! -buffer -nargs=0 GhcModCheck call s:make('check')
 command! -buffer -nargs=0 GhcModLint call s:make('lint')
@@ -40,6 +41,7 @@ command! -buffer -nargs=0 GhcModCheckAndLintAsync call s:check_and_lint_async()
 command! -buffer -nargs=0 GhcModExpand call setqflist(ghcmod#expand()) | cwindow
 let b:undo_ftplugin .= join(map([
       \ 'GhcModType',
+      \ 'GhcModInfo',
       \ 'GhcModTypeClear',
       \ 'GhcModCheck',
       \ 'GhcModLint',

--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -48,6 +48,35 @@ function! ghcmod#clear_highlight()"{{{
   endif
 endfunction"}}}
 
+" Return the current haskell identifier
+function! ghcmod#getHaskellIdentifier()"{{{
+  let c = col ('.')-1
+  let l = line('.')
+  let ll = getline(l)
+  let ll1 = strpart(ll,0,c)
+  let ll1 = matchstr(ll1,"[a-zA-Z0-9_'.]*$")
+  let ll2 = strpart(ll,c,strlen(ll)-c+1)
+  let ll2 = matchstr(ll2,"^[a-zA-Z0-9_'.]*")
+  return ll1.ll2
+endfunction"}}}
+
+function! ghcmod#info()"{{{
+  if &l:modified
+    call ghcmod#print_warning('ghcmod#info: the buffer has been modified but not written')
+  endif
+  let l:fexp  = ghcmod#getHaskellIdentifier()
+  let l:file = expand('%:p')
+  if l:file ==# ''
+    call ghcmod#print_warning("current version of ghcmod.vim doesn't support running on an unnamed buffer.")
+    return ''
+  endif
+  let l:mod = ghcmod#detect_module()
+  let l:cmd = ghcmod#build_command(['info', l:file, l:mod, l:fexp])
+  let l:output = s:system(l:cmd)
+
+  return l:output
+endfunction"}}}
+
 function! ghcmod#type()"{{{
   if &l:modified
     call ghcmod#print_warning('ghcmod#type: the buffer has been modified but not written')

--- a/doc/ghcmod.txt
+++ b/doc/ghcmod.txt
@@ -16,6 +16,7 @@ License			|ghcmod-license|
 FEATURES                                                    *ghcmod-features*
 
 - Displaying the type of sub-expressions (ghc-mod type)
+- Displaying the info for identifiers (ghc-mod info)
 - Displaying error/warning messages and their locations (ghc-mod check and
   ghc-mod lint)
 - Displaying the expansion of splices (ghc-mod expand)
@@ -46,6 +47,9 @@ If you'd like to give GHC options, set |g:ghcmod_ghc_options|.
 
 	Sub-expressions are highlighted as |hl-Search| by default. You can
 	customize it by setting |g:ghcmod_type_highlight|.
+
+:GhcModInfo                                                      *:GhcModInfo*
+	Information about the identifier under the cursor is echoed.
 
 :GhcModTypeClear                                            *:GhcModTypeClear*
 	Clear the highlight created by |:GhcModType|.


### PR DESCRIPTION
This allows us to get detailed information about the current Haskell identifier (may be qualified) from ghc-mod. It is especially helpful in figuring out which package a particular function has been imported from.
