### PR TITLE
Add the '-fno-code' flag by default.

### DIFF
--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -418,7 +418,9 @@ function! ghcmod#build_command(args)"{{{
     endif
   endif
 
-  for l:opt in get(g:, 'ghcmod_ghc_options', [])
+  " Taking the -fno-code flag here results in a *massive* speed increase.
+  " Overrideable by the user setting g:ghcmod_ghc_options themselves.
+  for l:opt in get(g:, 'ghcmod_ghc_options', ["-fno-code"])
     call extend(l:cmd, ['-g', l:opt])
   endfor
   call extend(l:cmd, a:args)

--- a/doc/ghcmod.txt
+++ b/doc/ghcmod.txt
@@ -82,13 +82,20 @@ If you'd like to give GHC options, set |g:ghcmod_ghc_options|.
 GLOBAL VARIABLES                                     *ghcmod-global-variables*
 
 g:ghcmod_ghc_options                                    *g:ghcmod_ghc_options*
-	Pass these options to GHC. By default, ghcmod doesn't pass any GHC
-	options. When ghcmod finds a Cabal directory structure, ghcmod
-	automatically append suitable options for it.
+	Pass these options to GHC. By default, ghcmod only passes the
+	"-fno-code" option for performance reasons. Defining this variable
+	will prevent this, so if you want that option you should include
+	it manually. When ghcmod finds a Cabal directory structure,
+	ghcmod automatically appends suitable options for it.
 
-	Example: passing -idir1 and -idir2 to GHC
+	Example: passing ONLY -idir1 and -idir2 to GHC.
 >
 	let g:ghcmod_ghc_options = ['-idir1', '-idir2']
+<
+	Example: excluding the implicit "-fno-code". This was the default in
+	previous version of ghcmod.
+>
+	let g:ghcmod_ghc_options = []
 <
 
 g:ghcmod_hlint_options                                *g:ghcmod_hlint_options*


### PR DESCRIPTION
The -fno-code flag just runs the type checker instead of generating any output
code. Since that's all we actually want, this greatly increases ghcmod's
responsiveness. I haven't had any trouble with it, but it's easily overridden by
defining g:ghcmod_ghc_options.
