### PR TITLE
Allow an optional '>' before 'module' when detecting the module name.

### DIFF
--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -37,7 +37,7 @@ function! ghcmod#type(line, col, path, module) "{{{
 endfunction "}}}
 
 function! ghcmod#detect_module() "{{{
-  let l:regex = '^\C\s*module\s\+\zs[A-Za-z0-9.]\+'
+  let l:regex = '^\C>\=\s*module\s\+\zs[A-Za-z0-9.]\+'
   for l:lineno in range(1, line('$'))
     let l:line = getline(l:lineno)
     let l:pos = match(l:line, l:regex)


### PR DESCRIPTION
The regex now handles this kind of line in Bird format:

```
> module Foo where
```

Also, I had to make a symlink from haskell to lhaskell in after/ftplugin
to get lhs files to work.
