### PR TITLE
Fixes eagletmt/ghcmod-vim#40

### DIFF
--- a/autoload/ghcmod/util.vim
+++ b/autoload/ghcmod/util.vim
@@ -12,7 +12,7 @@ endfunction "}}}
 
 if vimproc#util#is_windows() " s:is_abspath {{{
   function! ghcmod#util#is_abspath(path)
-    return a:path =~? '^[a-z]:[\/]'
+    return a:path =~? '^[A-Za-z]:[\/]'
   endfunction
 else
   function! ghcmod#util#is_abspath(path)


### PR DESCRIPTION
It appears drive letters on my Win7 are labeled by uppercase letters. Previously ghcmod-vim did not recoginzed paths from uppercase as proper path and treated it like a simple filename.
