### PR TITLE
Use "ghc-mod version" to detect version instead of get_last_errmsg

### DIFF
--- a/autoload/ghcmod/util.vim
+++ b/autoload/ghcmod/util.vim
@@ -87,8 +87,6 @@ function! ghcmod#util#ghc_mod_version() "{{{
     endwhile
     call l:p.waitpid()
     let l:m = matchlist(l:r, 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
-    "call vimproc#system(['ghc-mod'])
-    "let l:m = matchlist(vimproc#get_last_errmsg(), 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
     let s:ghc_mod_version = l:m[1 : 3]
     call map(s:ghc_mod_version, 'str2nr(v:val)')
   endif


### PR DESCRIPTION
I was having trouble using ghcmod-vim on NixOS and tracked it down to the fact ghc-mod gets wrapped by a shell script for which vimproc#get_last_errmsg() returns nothing. This change calls 'ghc-mod version' to extract the version number instead which works with the wrapper.

Note: my VimL skills are weak so there may be a better way of doing this :)
