### PR TITLE
Add newlines to ghc-mod's info command.

### DIFF
--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -15,7 +15,7 @@ function! ghcmod#getHaskellIdentifier() "{{{
 endfunction "}}}
 
 function! ghcmod#info(fexp, path, module) "{{{
-  let l:cmd = ghcmod#build_command(['info', a:path, a:module, a:fexp])
+  let l:cmd = ghcmod#build_command(['info', "-b \n", a:path, a:module, a:fexp])
   let l:output = ghcmod#system(l:cmd)
   " Remove trailing newlines to prevent empty lines
   let l:output = substitute(l:output, '\n*$', '', '')


### PR DESCRIPTION
When running `ghc-mod info`, each line is separate by '\0' by default.
(This may have been added in ghc-mod version 4.0.)

I have added the `--boundary "\n"` flag in order to make all of the info
provided by the `ghc-mod info` command actually show up in the :echo
done by vim.

Without this flag, it looks like the output is getting cut off at the
first '\0'.

Here is an example `ghc-mod info` run, with and without -b.

```
$ ghc-mod -b $'\n' info Application.hs Application AppConfig
data AppConfig environment extra
  = AppConfig {appEnv :: environment,
               appPort :: Int,
               appRoot :: Text,
               appHost :: streaming-commons-0.1.2.4:Data.Streaming.Network.Internal.HostPreference,
               appExtra :: extra}
        -- Defined in ‘Yesod.Default.Config’
instance (Show environment, Show extra) =>
         Show (AppConfig environment extra)
  -- Defined in ‘Yesod.Default.Config’
$
```

```
$ ghc-mod -b $'\n' info Application.hs Application AppConfig
data AppConfig environment extra
  = AppConfig {appEnv :: environment,
               appPort :: Int,
               appRoot :: Text,
               appHost :: streaming-commons-0.1.2.4:Data.Streaming.Network.Internal.HostPreference,
               appExtra :: extra}
        -- Defined in ‘Yesod.Default.Config’
instance (Show environment, Show extra) =>
         Show (AppConfig environment extra)
  -- Defined in ‘Yesod.Default.Config’
$ ghc-mod info Application.hs Application AppConfig
data AppConfig environment extra  = AppConfig {appEnv :: environment,               appPort :: Int,               appRoot :: Text,               appHost :: streaming-commons-0.1.2.4:Data.Streaming.Network.Internal.HostPreference,               appExtra :: extra}       -- Defined in ‘Yesod.Default.Config’instance (Show environment, Show extra) =>         Show (AppConfig environment extra)  -- Defined in ‘Yesod.Default.Config’
$
```

You can see that it looks funny without the -b flag.  The full output also doesn't appear in vim.

Here are my :GhcModDiagnostics.

```
Current filetype: haskell                                                                                                              
filetype detection:ON  plugin:ON  indent:ON                                                                                            
ghcmod.vim version: 1.2.0                                                                                                              
ghc-mod is executable: 1                                                                                                               
vimproc.vim: 701                                                                                                                       
ghc-mod version: 4.1.1                                                                                                                 
ghc-mod debug command: ghc-mod -g -i/home/illabout/git/personal-blog-yesod/myblog/dist/build/autogen -g -I/home/illabout/git/personal-blog-yesod/myblog/dist/build/autogen -g -optP-include -g -optP/home/illabout/git/personal-blog-yesod/myblog/dist/build/autogen/cabal_macros.h -g -i/home/illabout/git/personal-blog-yesod/myblog/dist/build -g -I/home/illabout/git/personal-blog-yesod/myblog/dist/build -g -i /home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/autogen -g -I/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/autogen -g -optP-include -g -optP/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/autogen/cabal_macros.h -g -i/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/myblog/myblog-tmp -g -I/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/myblog/myblog-tmp -g -i/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/test/test-tmp -g -I/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/test/test-tmp-debug                                                                                                   
Root directory:      /home/illabout/git/personal-blog-yesod/myblog                                                                     
Current directory:   /home/illabout/git/personal-blog-yesod/myblog                                                                     
Cabal file:          /home/illabout/git/personal-blog-yesod/myblog/myblog.cabal                                                        
GHC options:         -i/home/illabout/git/personal-blog-yesod/myblog/dist/build/autogen -I/home/illabout/git/personal-blog-yesod/myblog
/dist/build/autogen -optP-include -optP/home/illabout/git/personal-blog-yesod/myblog/dist/build/autogen/cabal_macros.h -i/home/illabout
/git/personal-blog-yesod/myblog/dist/build -I/home/illabout/git/personal-blog-yesod/myblog/dist/build -i/home/illabout/git/personal-blo
g-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/autogen -I/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/buil
d/autogen -optP-include -optP/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/autogen/cabal_macros.h -i/h
ome/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/myblog/myblog-tmp -I/home/illabout/git/personal-blog-yesod
/myblog/dist/dist-sandbox-d98e3cc4/build/myblog/myblog-tmp -i/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/b
uild/test/test-tmp -I/home/illabout/git/personal-blog-yesod/myblog/dist/dist-sandbox-d98e3cc4/build/test/test-tmp -global-package-db -n
o-user-package-db -package-db /home/illabout/git/personal-blog-yesod/.cabal-sandbox/x86_64-linux-ghc-7.8.2-packages.conf.d -XTemplateHa
skell -XQuasiQuotes -XOverloadedStrings -XNoImplicitPrelude -XCPP -XMultiParamTypeClasses -XTypeFamilies -XGADTs -XGeneralizedNewtypeDe
riving -XFlexibleContexts -XEmptyDataDecls -XNoMonomorphismRestriction -XDeriveDataTypeable -XHaskell98 -optP-include -optP/home/illabo
ut/git/personal-blog-yesod/myblog/dist/build/autogen/cabal_macros.h                                                                    
Include directories: /home/illabout/git/personal-blog-yesod/myblog /home/illabout/git/personal-blog-yesod/myblog/app /home/illabout/git
/personal-blog-yesod/myblog/dist/build /home/illabout/git/personal-blog-yesod/myblog/dist/build/autogen /home/illabout/git/personal-blo
g-yesod/myblog/tests
Dependent packages:  aeson-0.7.0.6, base-4.7.0.0, bytestring-0.10.4.0, conduit-1.1.2.1, data-default-0.5.3, directory-1.2.1.0, fast-log
ger-2.1.5, hjsmin-0.1.4.6, hspec-1.9.5, http-conduit-2.1.2, monad-control-0.3.3.0, monad-logger-0.3.6.1, persistent-1.3.1.1, persistent
-mongoDB-1.3.1.1, persistent-template-1.3.1.3, resourcet-1.1.2.2, shakespeare-2.0.0.3, template-haskell-2.9.0.0, text-1.1.1.2, transfor
mers-0.3.0.0, wai-extra-2.1.1.1, wai-logger-2.1.1, warp-2.1.5.1, yaml-0.8.8.2, yesod-1.2.5.2, yesod-auth-1.3.0.5, yesod-core-1.2.15.1, 
yesod-form-1.3.9, yesod-static-1.2.3, yesod-test-1.2.1.5                                                                               
System libraries:    /usr/lib/ghc-7.8.2
```

This may be caused by ghc-mod version 4.0.  It could also be because of vimproc.  I guess it could also be because of ghc-7.8.
