### PR TITLE
Add preliminary support for ghc-modi

### DIFF
--- a/after/ftplugin/haskell/ghcmod.vim
+++ b/after/ftplugin/haskell/ghcmod.vim
@@ -57,6 +57,7 @@ command! -buffer -nargs=0 -bang GhcModCheckAsync call ghcmod#command#async_make(
 command! -buffer -nargs=0 -bang GhcModLintAsync call ghcmod#command#async_make('lint', <bang>0)
 command! -buffer -nargs=0 -bang GhcModCheckAndLintAsync call ghcmod#command#check_and_lint_async(<bang>0)
 command! -buffer -nargs=0 -bang GhcModExpand call ghcmod#command#expand(<bang>0)
+command! -buffer -nargs=0 -bang GhcModKillModi call ghcmod#command#kill_modi(<bang>0)
 let b:undo_ftplugin .= join(map([
       \ 'GhcModType',
       \ 'GhcModTypeInsert',
@@ -68,7 +69,8 @@ let b:undo_ftplugin .= join(map([
       \ 'GhcModCheckAsync',
       \ 'GhcModLintAsync',
       \ 'GhcModCheckAndLintAsync',
-      \ 'GhcModExpand'
+      \ 'GhcModExpand',
+      \ 'GhcModKillModi'
       \ ], '"delcommand " . v:val'), ' | ')
 let b:undo_ftplugin .= ' | unlet b:did_ftplugin_ghcmod'
 

--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -312,6 +312,16 @@ function! s:modi_command(args) "{{{
   endwhile
 endfunction "}}}
 
+function! ghcmod#kill_modi(sig) "{{{
+  if s:ghc_modi_proc == {}
+    return
+  endif
+  let l:ret = s:ghc_modi_proc.kill(a:sig)
+  call s:ghc_modi_proc.waitpid()
+  let s:ghc_modi_proc = {}
+  return l:ret
+endfunction "}}}
+
 function! ghcmod#system(...) "{{{
   lcd `=ghcmod#basedir()`
   let l:ret = call('vimproc#system', a:000)

--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -289,7 +289,7 @@ let s:ghc_modi_proc = {}
 
 function! s:modi_command(args) "{{{
   if s:ghc_modi_proc == {}
-    let l:ghcmodi_prog = s:build_command('ghc-modi', ['-b \n'])
+    let l:ghcmodi_prog = s:build_command('ghc-modi', ["-b \n"])
     lcd `=ghcmod#basedir()`
     let s:ghc_modi_proc = vimproc#popen2(ghcmodi_prog)
     lcd -

--- a/autoload/ghcmod/command.vim
+++ b/autoload/ghcmod/command.vim
@@ -221,6 +221,18 @@ function! ghcmod#command#expand(force) "{{{
   call s:open_quickfix()
 endfunction "}}}
 
+function! ghcmod#command#kill_modi(force) "{{{
+  if a:force
+    let l:sig = g:vimproc#SIGKILL
+  else
+    let l:sig = g:vimproc#SIGTERM
+  endif
+  let l:ret = ghcmod#kill_modi(l:sig)
+  if l:ret
+    echoerr vimproc#get_last_errmsg()
+  endif
+endfunction "}}}
+
 function! s:open_quickfix() "{{{
   let l:func = get(g:, 'ghcmod_open_quickfix_function', '')
   if empty(l:func)

--- a/test.sh
+++ b/test.sh
@@ -2,21 +2,39 @@
 
 shopt -s nullglob
 
+run_tests() {
+    for f in $1
+    do
+      testname=${f#test/test_}
+      testname=${testname%.vim}
+      echo "Running $testname"
+      rm -f verbose.log
+      if vim -e -N -u NONE $2 -S test/before.vim -S "$f" < /dev/null; then
+        cat stdout.log
+      else
+        retval=$[retval + 1]
+        cat stdout.log
+        cat verbose.log
+        echo
+      fi
+    done
+}
+
 retval=0
-for f in test/test_*.vim
-do
-  testname=${f#test/test_}
-  testname=${testname%.vim}
-  echo "Running $testname"
-  rm -f verbose.log
-  if vim -e -N -u NONE -S test/before.vim -S "$f" < /dev/null; then
-    cat stdout.log
-  else
-    retval=$[retval + 1]
-    cat stdout.log
-    cat verbose.log
-    echo
-  fi
-done
+
+modonly_tests=(test/test_type.vim test/test_info.vim)
+
+run_tests "test/test_*.vim"
+
+# we cannot programmatically set this in our test case vimscripts as the
+# variable is fixed once the script is loaded
+echo "Setting ghcmod_should_use_ghc_modi=0"
+
+TMPFILE=`mktemp /tmp/test.XXXXXX` || exit 1
+echo "let g:ghcmod_should_use_ghc_modi=0" >> $TMPFILE
+
+run_tests "${modonly_tests[*]}" "-S $TMPFILE"
+
+rm -f $TMPFILE
 
 exit $retval

--- a/test/test_type.vim
+++ b/test/test_type.vim
@@ -20,4 +20,10 @@ function! s:unit.test_type_compilation_failure()
   call self.assert.empty(l:types)
 endfunction
 
+function! s:unit.test_kill_recovery()
+  call s:unit.test_type()
+  call ghcmod#kill_modi(9)
+  call s:unit.test_type()
+endfunction
+
 call s:unit.run()


### PR DESCRIPTION
This enables the `check` and `info` functions to use `ghc-modi` if it is available. This addresses part of #48.

I had sketched an implementation for `make` as well, but it fails a lot of `ghcmod-vim`'s tests due to kazu-yamamoto/ghc-mod#275, so it's been left out for now.

Also, ghc-modi does not support spaces in filenames (kazu-yamamoto/ghc-mod#295), so `check` and `info` inherit this issue.

The `g:ghcmod_should_use_ghc_modi` flag determines whether the plugin attempts to use `ghc-modi`.
