### PR TITLE
Fix detection of version of ghc-mod.

### DIFF
--- a/autoload/ghcmod/util.vim
+++ b/autoload/ghcmod/util.vim
@@ -80,8 +80,8 @@ endfunction "}}}
 
 function! ghcmod#util#ghc_mod_version() "{{{
   if !exists('s:ghc_mod_version')
-    call vimproc#system(['ghc-mod'])
-    let l:m = matchlist(vimproc#get_last_errmsg(), 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
+    let l:ghcmod = vimproc#system(['ghc-mod','version'])
+    let l:m = matchlist(l:ghcmod, 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
     let s:ghc_mod_version = l:m[1 : 3]
     call map(s:ghc_mod_version, 'str2nr(v:val)')
   endif


### PR DESCRIPTION
Fix the following error:

Error detected while processing function ghcmod#util#check_version:
line    3:
E684: list index out of range: 0
E15: Invalid expression: a:version[l:i] > l:ghc_mod_version[l:i]
E684: list index out of range: 1
E15: Invalid expression: a:version[l:i] > l:ghc_mod_version[l:i]
E684: list index out of range: 2
E15: Invalid expression: a:version[l:i] > l:ghc_mod_version[l:i]
