### PR TITLE
ghc-mod version output could be on stdout

### DIFF
--- a/autoload/ghcmod/util.vim
+++ b/autoload/ghcmod/util.vim
@@ -80,8 +80,11 @@ endfunction "}}}
 
 function! ghcmod#util#ghc_mod_version() "{{{
   if !exists('s:ghc_mod_version')
-    call vimproc#system(['ghc-mod'])
-    let l:m = matchlist(vimproc#get_last_errmsg(), 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
+    let l:ghcmod_version_info = vimproc#system(['ghc-mod'])
+    if empty(l:ghcmod_version_info)
+      let l:ghcmod_version_info = vimproc#get_last_errmsg()
+    endif
+    let l:m = matchlist(l:ghcmod_version_info, 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
     let s:ghc_mod_version = l:m[1 : 3]
     call map(s:ghc_mod_version, 'str2nr(v:val)')
   endif


### PR DESCRIPTION
This checks whether ghc-mod's version output comes on stdout or stderr.
It is like pull request #57, but also checks for stderr.

I am seeing this error on both ghc-mod 5.0.1.2 and 4.1.6.

There is also an issue about this #58.
