### PR TITLE
fix version detection for new and old ghc-mod versions

### DIFF
--- a/autoload/ghcmod/util.vim
+++ b/autoload/ghcmod/util.vim
@@ -80,8 +80,16 @@ endfunction "}}}
 
 function! ghcmod#util#ghc_mod_version() "{{{
   if !exists('s:ghc_mod_version')
-    call vimproc#system(['ghc-mod'])
-    let l:m = matchlist(vimproc#get_last_errmsg(), 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
+    let l:ghcmod_version_info = vimproc#system(['ghc-mod', 'version'])
+    let l:m = matchlist(l:ghcmod_version_info, 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)\.\(\d\+\)')
+    if !len(l:m)
+      " That didn't work.  Try "ghc-mod" alone.
+      let l:ghcmod_version_info = vimproc#system(['ghc-mod'])
+      if empty(l:ghcmod_version_info)
+        let l:ghcmod_version_info = vimproc#get_last_errmsg()
+      endif
+      let l:m = matchlist(l:ghcmod_version_info, 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
+    endif
     let s:ghc_mod_version = l:m[1 : 3]
     call map(s:ghc_mod_version, 'str2nr(v:val)')
   endif


### PR DESCRIPTION
Should fix #58 #57 and #59

Tries new method with `ghc-mod version` with a fallback into the old method when it fails. 
