### PR TITLE
Updates version string parsing, since version 5 does not output version info in error message.

### DIFF
--- a/autoload/ghcmod/util.vim
+++ b/autoload/ghcmod/util.vim
@@ -80,6 +80,10 @@ endfunction "}}}
 
 function! ghcmod#util#ghc_mod_version() "{{{
   if !exists('s:ghc_mod_version')
+    let l:ver = vimproc#system(['ghc-mod'])  " works for ghc-mod versions >= 2.1.2  && < 5
+    if (!(match(l:ver, 'version') >= 0))
+      let l:ver = vimproc#system(['ghc-mod','version']) " alternative for ghc-mod versions >= 5
+    endif
     let l:m = matchlist(vimproc#system(['ghc-mod','version']), 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
     let s:ghc_mod_version = l:m[1 : 3]
     call map(s:ghc_mod_version, 'str2nr(v:val)')


### PR DESCRIPTION
As of ghc-mod version 5, running simply `ghc-mod` without argument gives:

`ghc-mod: No command given (try --help)`

rather than outputting the help info with the version info at the top. Instead of relying on that, ghc-mod vim should call `ghc-mod version` and parse the output of that. This also works with ghc-mod version 4.1.0 and above.

Syntastic solves this more holistically in order to support even older versions of ghc-mod, something else to consider:

https://github.com/scrooloose/syntastic/commit/d665fbf5641
