### PR TITLE
Changes build_command to work with ghc-mod version 5

### DIFF
--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -15,7 +15,7 @@ function! ghcmod#getHaskellIdentifier() "{{{
 endfunction "}}}
 
 function! ghcmod#info(fexp, path, module) "{{{
-  let l:cmd = ghcmod#build_command(['info', "-b \n", a:path, a:module, a:fexp])
+  let l:cmd = ghcmod#build_command('info', ["-b \n", a:path, a:module, a:fexp])
   let l:output = ghcmod#system(l:cmd)
   " Remove trailing newlines to prevent empty lines
   let l:output = substitute(l:output, '\n*$', '', '')
@@ -24,7 +24,7 @@ function! ghcmod#info(fexp, path, module) "{{{
 endfunction "}}}
 
 function! ghcmod#type(line, col, path, module) "{{{
-  let l:cmd = ghcmod#build_command(['type', a:path, a:module, a:line, a:col])
+  let l:cmd = ghcmod#build_command('type', [a:path, a:module, a:line, a:col])
   let l:output = ghcmod#system(l:cmd)
   let l:types = []
   for l:line in split(l:output, '\n')
@@ -113,7 +113,7 @@ function! ghcmod#parse_make(lines, basedir) "{{{
 endfunction "}}}
 
 function! s:build_make_command(type, path) "{{{
-  let l:cmd = ghcmod#build_command([a:type])
+  let l:cmd = ghcmod#build_command(a:type,[])
   if a:type ==# 'lint'
     for l:hopt in get(g:, 'ghcmod_hlint_options', [])
       call extend(l:cmd, ['-h', l:hopt])
@@ -176,7 +176,7 @@ function! ghcmod#expand(path) "{{{
   let l:dir = fnamemodify(a:path, ':h')
 
   let l:qflist = []
-  let l:cmd = ghcmod#build_command(['expand', "-b '\n'", a:path])
+  let l:cmd = ghcmod#build_command('expand', ["-b '\n'", a:path])
   for l:line in split(ghcmod#system(l:cmd), '\n')
     " path:line:col1-col2: message
     " or path:line:col: message
@@ -231,8 +231,8 @@ function! ghcmod#add_autogen_dir(path, cmd) "{{{
   endif
 endfunction "}}}
 
-function! ghcmod#build_command(args) "{{{
-  let l:cmd = ['ghc-mod']
+function! ghcmod#build_command(cmd, cmdargs) "{{{
+  let l:cmd = ['ghc-mod', a:cmd]
 
   let l:dist_top  = s:find_basedir() . '/dist'
   let l:sandboxes = split(glob(l:dist_top . '/dist-*', 1), '\n')
@@ -262,7 +262,7 @@ function! ghcmod#build_command(args) "{{{
   for l:opt in l:opts
     call extend(l:cmd, ['-g', l:opt])
   endfor
-  call extend(l:cmd, a:args)
+  call extend(l:cmd, a:cmdargs)
   return l:cmd
 endfunction "}}}
 

--- a/test/test_build_command.vim
+++ b/test/test_build_command.vim
@@ -1,5 +1,5 @@
 function! s:build()
-  return ghcmod#build_command(['do'])
+  return ghcmod#build_command('do',[])
 endfunction
 
 let s:unit = tinytest#new()
@@ -17,14 +17,14 @@ function! s:unit.test_build_with_dist_dir()
   try
     call system('cd test/data/with-cabal; cabal configure; cabal build')
     edit test/data/with-cabal/src/Foo/Bar.hs
-    call self.assert.equal(['ghc-mod',
+    call self.assert.equal(['ghc-mod', 'do',
           \ '-g', '-i' . fnamemodify('test/data/with-cabal/dist/build/autogen', ':p:h'),
           \ '-g', '-I' . fnamemodify('test/data/with-cabal/dist/build/autogen', ':p:h'),
           \ '-g', '-optP-include',
           \ '-g', '-optP' . fnamemodify('test/data/with-cabal/dist/build/autogen/cabal_macros.h', ':p'),
           \ '-g', '-i' . fnamemodify('test/data/with-cabal/dist/build', ':p:h'),
           \ '-g', '-I' . fnamemodify('test/data/with-cabal/dist/build', ':p:h'),
-          \ 'do'], s:build())
+          \ ], s:build())
   finally
     call system('cd test/data/with-cabal; rm -rf dist')
   endtry
@@ -34,7 +34,7 @@ function! s:unit.test_build_global_opt()
   let g:ghcmod_ghc_options = ['-Wall']
   try
     edit test/data/without-cabal/Main.hs
-    call self.assert.equal(['ghc-mod', '-g', '-Wall', 'do'], s:build())
+    call self.assert.equal(['ghc-mod', 'do', '-g', '-Wall'], s:build())
   finally
     unlet g:ghcmod_ghc_options
   endtry
@@ -46,7 +46,7 @@ function! s:unit.test_build_buffer_opt()
   let g:ghcmod_ghc_options = ['-Wall']
   try
     let b:ghcmod_ghc_options = ['-W']
-    call self.assert.equal(['ghc-mod', '-g', '-W', 'do'], s:build())
+    call self.assert.equal(['ghc-mod', 'do', '-g', '-W'], s:build())
   finally
     unlet g:ghcmod_ghc_options
   endtry


### PR DESCRIPTION
ghc-mod version 5 requires the command to be of the form:

```
ghc-mod {command} -g {ghcOpt} {commandArgs}
```

for example:

```
ghc-mod check -g -fno-warn-unused-binds path/to/File.hs ModuleName 1 2
```

In previous versions, the -g could be put right after ghc-mod (as ghcmod-vim does currently), or sometimes at the end of the whole thing, or other places; it was quite flexible. Now, the -g absolutely has to be in that position (which may be an error on the part of ghc-mod, but in any event is the behavior of current releases of version 5.*).

`ghcmod_build_make` is the only thing I was unsure of, and I wasn't able to run the tests so I'm not sure if the changes I did to them are working, but this is a step in the right direction at least.
