### PR TITLE
Improved support for operators

### DIFF
--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -11,6 +11,13 @@ function! ghcmod#getHaskellIdentifier() "{{{
   let ll1 = matchstr(ll1,"[a-zA-Z0-9_'.]*$")
   let ll2 = strpart(ll,c,strlen(ll)-c+1)
   let ll2 = matchstr(ll2,"^[a-zA-Z0-9_'.]*")
+  if ll1.ll2 == ""
+    let l:pat = "[!#$%&*+./<=>?@^|-~]*"
+    let ll1 = strpart(ll,0,c)
+    let ll1 = matchstr(ll1,l:pat."$")
+    let ll2 = strpart(ll,c,strlen(ll)-c+1)
+    let ll2 = matchstr(ll2,"^".l:pat)
+  endif
   return ll1.ll2
 endfunction "}}}
 


### PR DESCRIPTION
Makes :GhcModInfo work with operators. It's not perfect (does not support unicode symbols), but it's better than nothing and should cover most cases.