### PR TITLE
Add support for ghc-mod split

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Happy Haskell programming on Vim, powered by [ghc-mod](https://github.com/kazu-y
 - Displaying the type of sub-expressions (`ghc-mod type`)
 - Displaying error/warning messages and their locations (`ghc-mod check` and `ghc-mod lint`)
 - Displaying the expansion of splices (`ghc-mod expand`)
+- Insert split function cases (`ghc-mod split`)
 
 Completions are supported by another plugin.
 See [neco-ghc](https://github.com/eagletmt/neco-ghc) .

--- a/after/ftplugin/haskell/ghcmod.vim
+++ b/after/ftplugin/haskell/ghcmod.vim
@@ -48,6 +48,7 @@ endif
 
 command! -buffer -nargs=0 -bang GhcModType call ghcmod#command#type(<bang>0)
 command! -buffer -nargs=0 -bang GhcModTypeInsert call ghcmod#command#type_insert(<bang>0)
+command! -buffer -nargs=0 -bang GhcModSplitFunCase call ghcmod#command#split_function_case(<bang>0)
 command! -buffer -nargs=? -bang GhcModInfo call ghcmod#command#info(<q-args>, <bang>0)
 command! -buffer -nargs=0 GhcModTypeClear call ghcmod#command#type_clear()
 command! -buffer -nargs=? -bang GhcModInfoPreview call ghcmod#command#info_preview(<q-args>, <bang>0)

--- a/autoload/ghcmod/command.vim
+++ b/autoload/ghcmod/command.vim
@@ -56,6 +56,18 @@ function! ghcmod#command#type_clear() "{{{
   endif
 endfunction "}}}
 
+function! ghcmod#command#split_function_case(force) "{{{
+  let l:path = s:buffer_path(a:force)
+  if empty(l:path)
+    return
+  endif
+
+  let l:module = ghcmod#detect_module()
+  let l:decls = ghcmod#split(line('.'), col('.'), l:path, l:module)
+  echo l:decls
+
+endfunction "}}}
+
 function! ghcmod#command#type_insert(force) "{{{
   let l:path = s:buffer_path(a:force)
   if empty(l:path)

--- a/doc/ghcmod.txt
+++ b/doc/ghcmod.txt
@@ -20,6 +20,7 @@ FEATURES                                                    *ghcmod-features*
 - Displaying error/warning messages and their locations (ghc-mod check and
   ghc-mod lint)
 - Displaying the expansion of splices (ghc-mod expand)
+- Insert split function cases (ghc-mod split)
 
 Completions are supported by another plugin. See neco-ghc
 <https://github.com/eagletmt/neco-ghc>.
@@ -53,6 +54,23 @@ If you'd like to give GHC options, set |g:ghcmod_ghc_options|.
 
 :GhcModTypeInsert[!]                                       *:GhcModTypeInsert*
 	Insert a type signature under the cursor.
+
+	When the current buffer is modified, this command is disabled unless
+	"!" is given.
+
+:GhcModSplitFunCase[!]
+	Insert split function cases for the variable under the cursor.
+	Example:
+
+	    f :: [a] -> a
+	    f x = _body
+
+	When invoked with the cursor placed on x the following will be
+	inserted:
+
+	    f :: [a] -> a
+	    f [] = _body
+	    f (x:xs) = _ body
 
 	When the current buffer is modified, this command is disabled unless
 	"!" is given.


### PR DESCRIPTION
This adds support for the `ghc-mod split` command.

Seems to be working nicely. I could not invoke ghc-mod via simple system() call because
sadly individual lines are returned 0byte-separated by ghc-mod and in that case the system
call only returns the text up to the first 0 byte. 