### PR TITLE
Fix for tab indent

### DIFF
--- a/autoload/ghcmod/command.vim
+++ b/autoload/ghcmod/command.vim
@@ -20,7 +20,7 @@ endfunction "}}}
 
 function! ghcmod#command#type(force) "{{{
   let l:line = line('.')
-  let l:col = col('.')
+  let l:col = ghcmod#util#getcol()
 
   if exists('b:ghcmod_type')
     if b:ghcmod_type.spans(l:line, l:col)
@@ -69,7 +69,7 @@ function! ghcmod#command#type_insert(force) "{{{
   endif
 
   let l:module = ghcmod#detect_module()
-  let l:types = ghcmod#type(line('.'), col('.'), l:path, l:module)
+  let l:types = ghcmod#type(line('.'), ghcmod#util#getcol(), l:path, l:module)
   if empty(l:types) " Everything failed so let's just abort
     call ghcmod#util#print_error('ghcmod#command#type_insert: Cannot guess type')
     return

--- a/autoload/ghcmod/type.vim
+++ b/autoload/ghcmod/type.vim
@@ -52,6 +52,8 @@ function! s:ghcmod_type.highlight() "{{{
   endif
   call self.clear_highlight()
   let [l:line1, l:col1, l:line2, l:col2] = self.types[self.ix][0]
+  let l:col1 = ghcmod#util#tocol(l:line1, l:col1)
+  let l:col2 = ghcmod#util#tocol(l:line2, l:col2)
   let self.match_id = matchadd(self.group, '\%' . l:line1 . 'l\%' . l:col1 . 'c\_.*\%' . l:line2 . 'l\%' . l:col2 . 'c')
 endfunction "}}}
 

--- a/autoload/ghcmod/util.vim
+++ b/autoload/ghcmod/util.vim
@@ -46,6 +46,26 @@ function! ghcmod#util#join_path(dir, path) "{{{
   endif
 endfunction "}}}
 
+function! ghcmod#util#getcol() "{{{
+  let l:line = line('.')
+  let l:col = col('.')
+  let l:str = getline(l:line)[:(l:col - 1)]
+  let l:tabcnt = len(substitute(l:str, '[^\t]', '', 'g'))
+  return l:col + 7 * l:tabcnt
+endfunction "}}}
+
+function! ghcmod#util#tocol(line, col) "{{{
+  let l:str = getline(a:line)
+  let l:col = 0
+  for l:i in range(1, len(l:str))
+    let l:col += (l:str[l:i - 1] ==# "\t" ? 8 : 1)
+    if l:col >= a:col
+      return l:i
+    endif
+  endfor
+  return l:i + 1
+endfunction "}}}
+
 function! ghcmod#util#wait(proc) "{{{
   if has_key(a:proc, 'checkpid')
     return a:proc.checkpid()


### PR DESCRIPTION
If tab indentation exists, the command `GhcModType` does not work properly.
![ghcmod2](https://cloud.githubusercontent.com/assets/375258/6656982/6b3c3466-cb7f-11e4-98af-1d68acc36cc3.gif)
This pull request fixes this problem.
![ghcmod](https://cloud.githubusercontent.com/assets/375258/6656983/7075c172-cb7f-11e4-8a8d-1e3d26059598.gif)
Test code. (GitHub converts the tab indent to four spaces, so please substitute by the command `%s/^\s\+/\t/g`)
```haskell
main :: IO ()
main = do
	putStrLn "hello"
	putStrLn "world"
	putStrLn      $         "hello" ++ " world"
	putStrLn    (      "world"        ++    " hello"  )
```