### PR TITLE
Fix out of scope variable in ghcmod#util#tocol

### DIFF
--- a/autoload/ghcmod/util.vim
+++ b/autoload/ghcmod/util.vim
@@ -56,14 +56,15 @@ endfunction "}}}
 
 function! ghcmod#util#tocol(line, col) "{{{
   let l:str = getline(a:line)
+  let l:len = len(l:str)
   let l:col = 0
-  for l:i in range(1, len(l:str))
+  for l:i in range(1, l:len)
     let l:col += (l:str[l:i - 1] ==# "\t" ? 8 : 1)
     if l:col >= a:col
       return l:i
     endif
   endfor
-  return l:i + 1
+  return l:len + 1
 endfunction "}}}
 
 function! ghcmod#util#wait(proc) "{{{


### PR DESCRIPTION
Solves undefined variable error in line `return l:i + 1'.
```
Error detected while processing function <SNR>93_on_enter..338..ghcmod#util#tocol:
line    9:
E121: Undefined variable: l:i
Press ENTER or type command to continue
Error detected while processing function <SNR>93_on_enter..338..ghcmod#util#tocol:
line    9:
E15: Invalid expression: l:i + 1
Press ENTER or type command to continue
Error detected while processing function <SNR>93_on_enter..338..ghcmod#util#tocol:
line    9:
E121: Undefined variable: l:i
```