### PR TITLE
Symlink lhaskell -> haskell for literate haskell support

### DIFF
--- a/after/ftplugin/lhaskell/ghcmod.vim
+++ b/after/ftplugin/lhaskell/ghcmod.vim
@@ -1,0 +1,1 @@
+../haskell/ghcmod.vim


### PR DESCRIPTION
ghc-mod has builtin literate haskell support, symlinking seems to work fine.