### PR TITLE
Remove a:module arguments [fix for 5.5]

### DIFF
--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -14,17 +14,17 @@ function! ghcmod#getHaskellIdentifier() "{{{
   return ll1.ll2
 endfunction "}}}
 
-function! ghcmod#info(fexp, path, module) "{{{
-  let l:cmd = ghcmod#build_command(["-b \n", 'info', a:path, a:module, a:fexp])
+function! ghcmod#info(fexp, path, ...) "{{{
+  let l:cmd = ghcmod#build_command(["-b \n", 'info', a:path, a:fexp])
   let l:output = ghcmod#system(l:cmd)
   " Remove trailing newlines to prevent empty lines
   let l:output = substitute(l:output, '\n*$', '', '')
   return s:remove_dummy_prefix(l:output)
 endfunction "}}}
 
-function! ghcmod#split(line, col, path, module) "{{{
+function! ghcmod#split(line, col, path, ...) "{{{
   " `ghc-mod split` is available since v5.0.0.
-  let l:cmd = ghcmod#build_command(['split', a:path, a:module, a:line, a:col])
+  let l:cmd = ghcmod#build_command(['split', a:path, a:line, a:col])
   let l:lines = s:system('split', l:cmd)
   if empty(l:lines)
     return []
@@ -36,9 +36,9 @@ function! ghcmod#split(line, col, path, module) "{{{
   return split(l:parsed[5], '\n')
 endfunction "}}}
 
-function! ghcmod#sig(line, col, path, module) "{{{
+function! ghcmod#sig(line, col, path, ...) "{{{
   " `ghc-mod sig` is available since v5.0.0.
-  let l:cmd = ghcmod#build_command(['sig', a:path, a:module, a:line, a:col])
+  let l:cmd = ghcmod#build_command(['sig', a:path, a:line, a:col])
   let l:lines = s:system('sig', l:cmd)
   if len(l:lines) < 3
     return []
@@ -46,8 +46,8 @@ function! ghcmod#sig(line, col, path, module) "{{{
   return [l:lines[0], l:lines[2 :]]
 endfunction "}}}
 
-function! ghcmod#type(line, col, path, module) "{{{
-  let l:cmd = ghcmod#build_command(['type', a:path, a:module, a:line, a:col])
+function! ghcmod#type(line, col, path, ...) "{{{
+  let l:cmd = ghcmod#build_command(['type', a:path, a:line, a:col])
   let l:output = ghcmod#system(l:cmd)
   let l:types = []
   for l:line in split(l:output, '\n')

--- a/autoload/ghcmod/command.vim
+++ b/autoload/ghcmod/command.vim
@@ -37,7 +37,7 @@ function! ghcmod#command#type(force) "{{{
     return
   endif
 
-  let l:types = ghcmod#type(l:line, l:col, l:path, ghcmod#detect_module())
+  let l:types = ghcmod#type(l:line, l:col, l:path)
   if empty(l:types)
     call ghcmod#util#print_error('ghcmod#command#type: Cannot guess type')
     return
@@ -62,8 +62,7 @@ function! ghcmod#command#split_function_case(force) "{{{
     return
   endif
 
-  let l:module = ghcmod#detect_module()
-  let l:decls = ghcmod#split(line('.'), col('.'), l:path, l:module)
+  let l:decls = ghcmod#split(line('.'), col('.'), l:path)
   if empty(l:decls)
     call ghcmod#util#print_warning('No splittable constructor')
     return
@@ -79,7 +78,7 @@ function! ghcmod#command#initial_code_from_signature(force) "{{{
     return
   endif
 
-  let l:initial_code = ghcmod#sig(line('.'), col('.'), l:path, ghcmod#detect_module())
+  let l:initial_code = ghcmod#sig(line('.'), col('.'), l:path)
   if empty(l:initial_code)
     call ghcmod#util#print_warning('Cannot generate initial code')
     return
@@ -106,8 +105,7 @@ function! ghcmod#command#type_insert(force) "{{{
     return
   endif
 
-  let l:module = ghcmod#detect_module()
-  let l:types = ghcmod#type(line('.'), ghcmod#util#getcol(), l:path, l:module)
+  let l:types = ghcmod#type(line('.'), ghcmod#util#getcol(), l:path)
   if empty(l:types) " Everything failed so let's just abort
     call ghcmod#util#print_error('ghcmod#command#type_insert: Cannot guess type')
     return
@@ -117,7 +115,7 @@ function! ghcmod#command#type_insert(force) "{{{
   let [_, l:offset, _, _] = l:locsym
 
   if l:offset == 1 " We're doing top-level, let's try to use :info instead
-    let l:info = ghcmod#info(l:fexp, l:path, l:module)
+    let l:info = ghcmod#info(l:fexp, l:path)
     if !empty(l:info) " Continue only if we don't find errors
       let l:info = substitute(l:info, '\n\|\t.*', "", "g") " Remove extra lines
       let l:info = substitute(l:info, '\s\+', " ", "g") " Compress whitespace
@@ -137,7 +135,7 @@ function! s:info(fexp, force) "{{{
   if empty(l:fexp)
     let l:fexp = ghcmod#getHaskellIdentifier()
   end
-  return ghcmod#info(l:fexp, l:path, ghcmod#detect_module())
+  return ghcmod#info(l:fexp, l:path)
 endfunction "}}}
 
 function! ghcmod#command#info(fexp, force) "{{{

--- a/test/test_info.vim
+++ b/test/test_info.vim
@@ -1,5 +1,5 @@
 function! s:info(fexp)
-  return ghcmod#info(a:fexp, expand('%:p'), ghcmod#detect_module())
+  return ghcmod#info(a:fexp, expand('%:p'))
 endfunction
 
 let s:unit = tinytest#new()

--- a/test/test_split.vim
+++ b/test/test_split.vim
@@ -2,7 +2,7 @@ let s:unit = tinytest#new()
 
 function! s:unit.test_split()
   edit test/data/split/Split.hs
-  let l:decls = ghcmod#split(4, 3, expand('%:p'), 'Split')
+  let l:decls = ghcmod#split(4, 3, expand('%:p'))
   call self.assert.equal(['f [] = undefined', 'f (x:xs) = undefined'], l:decls)
 endfunction
 

--- a/test/test_type.vim
+++ b/test/test_type.vim
@@ -6,7 +6,7 @@ endfunction
 
 function! s:unit.test_type()
   edit test/data/with-cabal/src/Foo.hs
-  let l:types = ghcmod#type(4, 7, expand('%:p'), ghcmod#detect_module())
+  let l:types = ghcmod#type(4, 7, expand('%:p'))
   call self.assert.equal([
         \ [[4, 7, 4, 10], '[Char]'],
         \ [[4, 7, 4, 16], '[Char]'],
@@ -16,7 +16,7 @@ endfunction
 
 function! s:unit.test_type_compilation_failure()
   edit test/data/failure/Main.hs
-  let l:types = ghcmod#type(4, 7, expand('%:p'), ghcmod#detect_module())
+  let l:types = ghcmod#type(4, 7, expand('%:p'))
   call self.assert.empty(l:types)
 endfunction
 


### PR DESCRIPTION
Remove the 'a:module' arguments from the calls to `ghcmod#build_command` in
the sig, split, info, and type functions. No version check because they've
actually been optional since v5.0, but now they have been removed completely.

Also replace them with `...` in the function's argument list, so that calls
with or without them are accepted, In case there are any other plugins based
on ghcmod-vim. For the same reason, `ghcmod#detect_module` is still there.