### PR TITLE
Treat Suggestions as warnings in quickfix

### DIFF
--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -108,6 +108,8 @@ function! ghcmod#parse_make(lines, basedir) "{{{
     if l:rest =~# '^Warning:'
       let l:qf.type = 'W'
       let l:rest = matchstr(l:rest, '^Warning:\s*\zs.*$')
+    elseif l:rest =~# '^Suggestion:'
+      let l:qf.type = 'W'
     elseif l:rest =~# '^Error:'
       let l:qf.type = 'E'
       let l:rest = matchstr(l:rest, '^Error:\s*\zs.*$')


### PR DESCRIPTION
  Currently, `Suggestion`s from`ghc-mod lint` are treated as errors because [`ghcmod#parse_make`](https://github.com/eagletmt/ghcmod-vim/blob/1d192d13d68ab59f9f46497a0909bf24a7b7dfff/autoload/ghcmod.vim#L108-L116)  doesn't handle messages starting with `Suggestion:`.  I think these suggestions are better treated as warnings rather than errors. What do you think?

  For example, for this code

``` haskell
main = putStrLn $ "Hi"
```

```
before : |1 col 8 error| Suggestion: Redundant $
after  : |1 col 8 warning| Suggestion: Redundant $
```

Edit: I wasn't able to update/add test for this, as the tests don't seem to be working in my environment (I haven't investigated further). Let me know if there's anything I should do.
