### PR TITLE
Remove duplicated entry from docs

### DIFF
--- a/doc/ghcmod.txt
+++ b/doc/ghcmod.txt
@@ -108,14 +108,6 @@ If you'd like to give GHC options, set |g:ghcmod_ghc_options|.
 	When the current buffer is modified, this command is disabled unless
 	"!" is given.
 
-:GhcModInfoPreview[!] {identifier}
-	Information about {identifier} is displayed in the preview window.
-	Info accumulates until the preview window is closed or renamed,
-	for example by a different command.
-
-	When the current buffer is modified, this command is disabled unless
-	"!" is given.
-
 :GhcModTypeClear                                            *:GhcModTypeClear*
 	Clear the highlight created by |:GhcModType|.
 


### PR DESCRIPTION
Dunno if I'm overlooking something but it seems that docs for `GhcModInfoPreview` were duplicated. I kept the one I feel was more complete.