### PR TITLE
Add support for sandboxed ghc-mod via `stack exec`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ It shows your environment information possibly related to ghcmod.vim.
 - Filetype status
     - ghcmod.vim is a ftplugin. See `:help filetype-overview` and `:help filetype-plugins`.
 - ghc-mod executable
-    - ghcmod.vim requires [ghc-mod](https://github.com/kazu-yamamoto/ghc-mod) and it must be placed in your `$PATH`.
+    - ghcmod.vim requires [ghc-mod](https://github.com/kazu-yamamoto/ghc-mod). It must be placed in your `$PATH` or must be executable via `stack exec`
 - vimproc.vim
     - ghcmod.vim requires [vimproc.vim](https://github.com/Shougo/vimproc.vim).
 - ghc-mod version

--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ ghcmod-vim will insert:
     cString x = _cString_body
 ```
 
+## Stack Support
+If you've built/installed ghc-mod using stack and typically invoke it using `stack exec -- ghc-mod ...`, just set `g:ghcmod_stack_exec = 1` in your `~/.vimrc`
+
 ## Customize
 See wiki page [Customize](https://github.com/eagletmt/ghcmod-vim/wiki/Customize).
 

--- a/after/ftplugin/haskell/ghcmod.vim
+++ b/after/ftplugin/haskell/ghcmod.vim
@@ -22,7 +22,13 @@ endif
 if !exists('s:has_ghc_mod')
   let s:has_ghc_mod = 0
 
-  if !executable('ghc-mod')
+  if get(g:, "ghcmod_stack_exec", 0)
+    let s:ghcmod_path = substitute(system('stack exec -- which ghc-mod'), '\n\+$', '', '')
+  else
+    let s:ghcmod_path = 'ghc-mod'
+  endif
+
+  if !executable(s:ghcmod_path)
     call ghcmod#util#print_error('ghcmod: ghc-mod is not executable!')
     finish
   endif

--- a/autoload/ghcmod.vim
+++ b/autoload/ghcmod.vim
@@ -245,7 +245,7 @@ function! ghcmod#add_autogen_dir(path, cmd) "{{{
 endfunction "}}}
 
 function! ghcmod#build_command(args) "{{{
-  let l:cmd = ['ghc-mod', '--silent']
+  let l:cmd = ghcmod#util#basic_command() + ['--silent']
 
   let l:dist_top  = s:find_basedir() . '/dist'
   let l:sandboxes = split(glob(l:dist_top . '/dist-*', 1), '\n')
@@ -334,6 +334,7 @@ function! ghcmod#basedir() "{{{
 endfunction "}}}
 
 function! s:find_basedir() "{{{
+  let args = ghcmod#util#basic_command() + ['--silent', 'root']
   " search Cabal file
   if !exists('b:ghcmod_basedir')
     " `ghc-mod root` is available since v4.0.0.
@@ -341,7 +342,7 @@ function! s:find_basedir() "{{{
     try
       lcd `=expand('%:p:h')`
       let b:ghcmod_basedir =
-        \ substitute(vimproc#system(['ghc-mod', '--silent', 'root']), '\n*$', '', '')
+        \ substitute(vimproc#system(args), '\n*$', '', '')
     finally
       lcd `=l:dir`
     endtry

--- a/autoload/ghcmod/util.vim
+++ b/autoload/ghcmod/util.vim
@@ -38,6 +38,16 @@ else
   endfunction
 endif "}}}
 
+function! ghcmod#util#basic_command()
+  " Should we invoke ghc-mod via `stack exec -- ghc-mod`?
+  if get(g:, "ghcmod_stack_exec", 0)
+    let args = ['stack', 'exec', '--', 'ghc-mod']
+  else
+    let args = ['ghc-mod']
+  endif
+  return args
+endfunction
+
 function! ghcmod#util#join_path(dir, path) "{{{
   if ghcmod#util#is_abspath(a:path)
     return a:path
@@ -106,7 +116,8 @@ endfunction "}}}
 
 function! ghcmod#util#ghc_mod_version() "{{{
   if !exists('s:ghc_mod_version')
-    let l:ghcmod = vimproc#system(['ghc-mod','version'])
+    let l:cmd = ghcmod#util#basic_command() + ['version']
+    let l:ghcmod = vimproc#system(l:cmd)
     let l:m = matchlist(l:ghcmod, 'version \(\d\+\)\.\(\d\+\)\.\(\d\+\)')
     if empty(l:m)
       if match(l:ghcmod, 'version 0 ') == -1

--- a/doc/ghcmod.txt
+++ b/doc/ghcmod.txt
@@ -233,6 +233,9 @@ g:ghcmod_open_quickfix_function              *g:ghcmod_open_quickfix_function*
 	  CtrlPQuickfix
 	endfunction
 <
+
+g:ghcmod_stack_exec                                      *g:ghcmod_stack_exec*
+  This flag modifies ghcmod-vim to invoke ghc-mod via `stack exec -- ghc-mod`.
 ==============================================================================
 CUSTOMIZE                                                   *ghcmod-customize*
 


### PR DESCRIPTION
This commit adds a new global variable, `g:ghcmod_stack_exec`, which
when set to 1 will execute ghc-mod via `stack exec -- ghc-mod` instead
of trying to use `ghc-mod` via `~/.local/bin`.

This effectively adds support for sandboxed ghc-mod via stack on a
per-project or per-compiler-version basis.

I believe this should resolve #88 and potentially #84. 